### PR TITLE
歌单ID正则表达式优化

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -8,8 +8,8 @@ const more = ref(true);
 const songs = usesongstore();
 
 async function search() {
-  const single = q.value.match(/music\.163\.com\/#\/song\?id=(\d+)/);
-  const playlist = q.value.match(/music\.163\.com\/#\/playlist\?id=(\d+)/);
+  const single = q.value.match(/^https?:\/\/music\.163\.com\/.*?song\?id=(\d+)/);
+  const playlist = q.value.match(/^https?:\/\/music\.163\.com\/.*?playlist\?id=(\d+)/);
 
   if (single) {
     const res: any = await useFetch(api.netease.detail(single[1]));


### PR DESCRIPTION
https://github.com/Beadd/Creamplayer/issues/81

修改正则表达式适配一些此前无法识别的 url

https://music.163.com/playlist?id=
https://music.163.com/m/playlist?id=
https://music.163.com/#/playlist?id=